### PR TITLE
Cors/access limit

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,6 @@
   "trailingComma": "es5",
   "tabWidth": 2,
   "semi": true,
-  "singleQuote": true,
+  "singleQuote": false,
   "endOfLine": "lf"
 }

--- a/cors-service/serverless.yml
+++ b/cors-service/serverless.yml
@@ -6,7 +6,7 @@ service: cors
 custom:
   customDomain:
     domainName: cors.bridged.cc
-    basePath: ''
+    basePath: ""
     stage: ${self:provider.stage}
     createRoute53Record: true
   serverless-offline:
@@ -14,6 +14,7 @@ custom:
 
 provider:
   name: aws
+  memorySize: 128
   runtime: nodejs12.x
   apiGateway:
     shouldStartNameWithService: true
@@ -32,7 +33,7 @@ functions:
           method: get
 
 plugins:
-  - '@hewmen/serverless-plugin-typescript'
+  - "@hewmen/serverless-plugin-typescript"
   - serverless-plugin-optimize
   - serverless-offline
   - serverless-domain-manager


### PR DESCRIPTION
CORS Lambda function memory limit from `1024` to `128`

The service will still be free & open to anyone without access limit (limiting the memory instead for now.)

Ref: https://github.com/bridgedxyz/base/issues/23