### PR TITLE
CORS - Preserve cookies from proxy response header

### DIFF
--- a/cors-service/lib/cors.ts
+++ b/cors-service/lib/cors.ts
@@ -95,9 +95,6 @@ function onProxyResponse(proxy, proxyReq, proxyRes, req, res) {
     }
   }
 
-  delete proxyRes.headers['set-cookie'];
-  delete proxyRes.headers['set-cookie2'];
-
   proxyRes.headers['x-final-url'] = requestState.location.href;
   withCORS(proxyRes.headers, req);
   return true;


### PR DESCRIPTION
Closes #26 and probably related to #20.
Removed the lines which was deleting the `set-cookie` headers.